### PR TITLE
Rename `Create` to `Builder` in ChatCompletionRequestBuilder

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -15,9 +15,9 @@
     <PackageIcon>favicon.png</PackageIcon>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Groq, API, .NET Core SDK, AI, LLM, Chat, Vision, Audio, TTS, STT</PackageTags>
-    <AssemblyVersion>2.0.0.7</AssemblyVersion>
-    <FileVersion>2.0.0.7</FileVersion>
-    <Version>2.0.0.7-alpha</Version>
+    <AssemblyVersion>2.0.0.8</AssemblyVersion>
+    <FileVersion>2.0.0.8</FileVersion>
+    <Version>2.0.0.8-alpha</Version>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
 </Project>

--- a/Groq.Core/Builders/ChatCompletionRequestBuilder.cs
+++ b/Groq.Core/Builders/ChatCompletionRequestBuilder.cs
@@ -68,12 +68,12 @@ public class ChatCompletionRequestBuilder
     /// <exception cref="ArgumentNullException">Thrown when messages is null.</exception>
     /// <remarks>
     ///     <para>
-    ///         <b>IMPORTANT:</b> If this method is used to set messages directly, the following methods will have 
-    ///         no effect even if called: <see cref="WithUserPrompt"/>, <see cref="WithSystemPrompt"/>, 
+    ///         <b>IMPORTANT:</b> If this method is used to set messages directly, the following methods will have
+    ///         no effect even if called: <see cref="WithUserPrompt"/>, <see cref="WithSystemPrompt"/>,
     ///         <see cref="WithAssistantPrompt"/>, and <see cref="WithImageUrl"/>.
     ///     </para>
     ///     <para>
-    ///         Use this method when you need full control over the message structure, or use the convenience 
+    ///         Use this method when you need full control over the message structure, or use the convenience
     ///         methods (WithUserPrompt, etc.) to automatically build the messages array.
     ///     </para>
     /// </remarks>
@@ -94,12 +94,12 @@ public class ChatCompletionRequestBuilder
     /// <exception cref="ArgumentException">Thrown when userPrompt is null or empty.</exception>
     /// <remarks>
     ///     <para>
-    ///         This is a convenience method that automatically builds the messages array. The user prompt is required 
+    ///         This is a convenience method that automatically builds the messages array. The user prompt is required
     ///         and will be included in the final request as a message with role "user".
     ///     </para>
     ///     <para>
-    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called. 
-    ///         Use either WithMessages for full control, or use this method along with <see cref="WithSystemPrompt"/>, 
+    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called.
+    ///         Use either WithMessages for full control, or use this method along with <see cref="WithSystemPrompt"/>,
     ///         <see cref="WithAssistantPrompt"/>, and <see cref="WithImageUrl"/> for automatic message building.
     ///     </para>
     /// </remarks>
@@ -120,12 +120,12 @@ public class ChatCompletionRequestBuilder
     /// <exception cref="ArgumentException">Thrown when systemPrompt is null or empty.</exception>
     /// <remarks>
     ///     <para>
-    ///         This is a convenience method that automatically builds the messages array. The system prompt is optional 
+    ///         This is a convenience method that automatically builds the messages array. The system prompt is optional
     ///         and will be included as the first message with role "system" if provided.
     ///     </para>
     ///     <para>
-    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called. 
-    ///         Use either WithMessages for full control, or use this method along with <see cref="WithUserPrompt"/> 
+    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called.
+    ///         Use either WithMessages for full control, or use this method along with <see cref="WithUserPrompt"/>
     ///         for automatic message building.
     ///     </para>
     /// </remarks>
@@ -146,13 +146,13 @@ public class ChatCompletionRequestBuilder
     /// <exception cref="ArgumentException">Thrown when assistantPrompt is null or empty.</exception>
     /// <remarks>
     ///     <para>
-    ///         This is a convenience method that automatically builds the messages array. The assistant prompt is optional 
-    ///         and will be included as a message with role "assistant" if provided, positioned after the system message 
+    ///         This is a convenience method that automatically builds the messages array. The assistant prompt is optional
+    ///         and will be included as a message with role "assistant" if provided, positioned after the system message
     ///         (if any) and before the user message.
     ///     </para>
     ///     <para>
-    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called. 
-    ///         Use either WithMessages for full control, or use this method along with <see cref="WithUserPrompt"/> 
+    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called.
+    ///         Use either WithMessages for full control, or use this method along with <see cref="WithUserPrompt"/>
     ///         for automatic message building.
     ///     </para>
     /// </remarks>
@@ -173,12 +173,12 @@ public class ChatCompletionRequestBuilder
     /// <exception cref="ArgumentException">Thrown when imageUrl is null or empty.</exception>
     /// <remarks>
     ///     <para>
-    ///         This is a convenience method that automatically builds the messages array with multimodal content. 
+    ///         This is a convenience method that automatically builds the messages array with multimodal content.
     ///         The image URL is optional and will be included in the user message content alongside the text prompt.
     ///     </para>
     ///     <para>
-    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called. 
-    ///         Use either WithMessages for full control over multimodal content, or use this method along with 
+    ///         <b>NOTE:</b> This method has no effect if <see cref="WithMessages"/> was previously called.
+    ///         Use either WithMessages for full control over multimodal content, or use this method along with
     ///         <see cref="WithUserPrompt"/> for automatic message building with vision support.
     ///     </para>
     ///     <para>
@@ -812,5 +812,5 @@ public class ChatCompletionRequestBuilder
     ///     Creates a new instance of ChatCompletionRequestBuilder.
     /// </summary>
     /// <returns>A new ChatCompletionRequestBuilder instance.</returns>
-    public static ChatCompletionRequestBuilder Create() => new();
+    public static ChatCompletionRequestBuilder Builder() => new();
 }

--- a/Groq.Core/Clients/ToolClient.cs
+++ b/Groq.Core/Clients/ToolClient.cs
@@ -62,7 +62,7 @@ public sealed class ToolClient
             }));
 
             var request = ChatCompletionRequestBuilder
-                .Create()
+                .Builder()
                 .WithModel(model)
                 .WithUserPrompt(userPrompt)
                 .WithSystemPrompt(systemMessage)

--- a/Groq.Core/Clients/VisionClient.cs
+++ b/Groq.Core/Clients/VisionClient.cs
@@ -70,7 +70,7 @@ public sealed class VisionClient
         ValidateImageUrl(imageUrl);
 
         var builder = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model)
             .WithUserPrompt(prompt)
             .WithImageUrl(imageUrl);
@@ -104,7 +104,7 @@ public sealed class VisionClient
         ValidateBase64Size(base64Image);
 
         var builder = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model)
             .WithUserPrompt(prompt)
             .WithImageUrl($"data:image/jpeg;base64,{base64Image}");
@@ -152,7 +152,7 @@ public sealed class VisionClient
         }));
 
         var builder = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model)
             .WithUserPrompt(prompt)
             .WithImageUrl(imageUrl)
@@ -181,7 +181,7 @@ public sealed class VisionClient
         ValidateImageUrl(imageUrl);
 
         var request = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model)
             .WithUserPrompt(prompt)
             .WithImageUrl(imageUrl)

--- a/Groq.Core/Providers/LlmTextProvider.cs
+++ b/Groq.Core/Providers/LlmTextProvider.cs
@@ -64,7 +64,7 @@ public sealed class LlmTextProvider
         ArgumentNullException.ThrowIfNull(userPrompt);
 
         var builder = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model ?? _model)
             .WithUserPrompt(userPrompt);
 
@@ -106,7 +106,7 @@ public sealed class LlmTextProvider
         ArgumentNullException.ThrowIfNull(userPrompt);
 
         var builder = ChatCompletionRequestBuilder
-            .Create()
+            .Builder()
             .WithModel(model ?? _model)
             .WithUserPrompt(userPrompt);
 

--- a/Groq.Tests.Unit/Builders/ChatCompletionRequestBuilder/FluentApiTests.cs
+++ b/Groq.Tests.Unit/Builders/ChatCompletionRequestBuilder/FluentApiTests.cs
@@ -550,27 +550,27 @@ public class FluentApiTests
     [Fact]
     public void Builder_Should_Use_Static_Create_Method()
     {
-        // Act - Create builder using static factory method
-        var builder = Core.Builders.ChatCompletionRequestBuilder.Create();
+        // Act - Builder builder using static factory method
+        var builder = Core.Builders.ChatCompletionRequestBuilder.Builder();
 
-        // Assert - Verify Create() returns a new instance
+        // Assert - Verify Builder() returns a new instance
         builder.ShouldNotBeNull();
         builder.ShouldBeOfType<Core.Builders.ChatCompletionRequestBuilder>();
 
-        // Assert - Verify each call to Create() returns a new instance
-        var builder2 = Core.Builders.ChatCompletionRequestBuilder.Create();
+        // Assert - Verify each call to Builder() returns a new instance
+        var builder2 = Core.Builders.ChatCompletionRequestBuilder.Builder();
         builder2.ShouldNotBeNull();
         builder2.ShouldBeOfType<Core.Builders.ChatCompletionRequestBuilder>();
         builder2.ShouldNotBeSameAs(builder); // Different instances
 
         // Assert - Verify the created builder can be used for method chaining
-        var request = Core.Builders.ChatCompletionRequestBuilder.Create()
+        var request = Core.Builders.ChatCompletionRequestBuilder.Builder()
             .WithModel(DefaultModel)
             .WithUserPrompt(UserPrompt)
             .WithTemperature(TemperatureValue)
             .Build();
 
-        // Assert - Verify the builder created via Create() produces valid requests
+        // Assert - Verify the builder created via Builder() produces valid requests
         request.ShouldNotBeNull();
         request.ShouldContainKey("model");
         request.ShouldContainKey("messages");

--- a/Groq.Tests.Unit/Models/ModelResponseJsonValidationTests.cs
+++ b/Groq.Tests.Unit/Models/ModelResponseJsonValidationTests.cs
@@ -104,7 +104,7 @@ public class ModelResponseJsonValidationTests
     [Fact]
     public void Model_Should_Handle_Round_Trip_Serialization()
     {
-        // Arrange - Create a model, serialize it, deserialize it, and compare
+        // Arrange - Builder a model, serialize it, deserialize it, and compare
         var originalModel = new Model
         {
             Id = "llama-guard-3-8b",

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 J. Gravelle
+Copyright (c) 2025 J. Gravelle, Mohamed Al-Adawy
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ refactored and enhanced.
 
 ### Current Release
 
-**Version:** `2.0.0.7-alpha`
+**Version:** `2.0.0.8-alpha`
 
 > **⚠️ ALPHA RELEASE - NOT PRODUCTION READY**
 > This is an alpha release with the new architecture featuring:
 >
-> -   ✨ **NEW in v2.0.0.7:** Enhanced ChatCompletionRequestBuilder API with separate methods
+> -   ✨ **NEW in v2.0.0.8:** Enhanced ChatCompletionRequestBuilder API with separate methods
 > -   ✨ **NEW:** ChatCompletionRequestBuilder for fluent request construction
 > -   ✨ GroqClient unified interface
 > -   ✨ GroqOptions configuration system
@@ -105,7 +105,7 @@ refactored and enhanced.
 >
 > **For testing and development only.** APIs are subject to change before stable release.
 >
-> **Breaking Changes in v2.0.0.7:**
+> **Breaking Changes in v2.0.0.8:**
 >
 > -   `WithMessages(string, string?)` replaced with separate methods: `WithUserPrompt()`, `WithSystemPrompt()`, `WithAssistantPrompt()`, `WithImageUrl()`
 > -   See [Migration Guide](#migration-guide-v2004---v2005) below for details
@@ -119,13 +119,13 @@ The SDK is split into two packages for better modularity:
 Core SDK containing all API clients, models, providers, and the new ChatCompletionRequestBuilder.
 
 ```bash
-dotnet add package Groq.Sdk.Core --version 2.0.0.7-alpha
+dotnet add package Groq.Sdk.Core --version 2.0.0.8-alpha
 ```
 
 Or via Package Manager Console:
 
 ```powershell
-Install-Package Groq.Sdk.Core -Version 2.0.0.7-alpha
+Install-Package Groq.Sdk.Core -Version 2.0.0.8-alpha
 ```
 
 #### **Groq.Sdk.Extensions.DependencyInjection** (Optional)
@@ -133,20 +133,20 @@ Install-Package Groq.Sdk.Core -Version 2.0.0.7-alpha
 Dependency injection extensions for ASP.NET Core and .NET Generic Host applications.
 
 ```bash
-dotnet add package Groq.Sdk.Extensions.DependencyInjection --version 2.0.0.7-alpha
+dotnet add package Groq.Sdk.Extensions.DependencyInjection --version 2.0.0.8-alpha
 ```
 
 Or via Package Manager Console:
 
 ```powershell
-Install-Package Groq.Sdk.Extensions.DependencyInjection -Version 2.0.0.7-alpha
+Install-Package Groq.Sdk.Extensions.DependencyInjection -Version 2.0.0.8-alpha
 ```
 
 ### Quick Install (Both Packages)
 
 ```bash
-dotnet add package Groq.Sdk.Core --version 2.0.0.7-alpha
-dotnet add package Groq.Sdk.Extensions.DependencyInjection --version 2.0.0.7-alpha
+dotnet add package Groq.Sdk.Core --version 2.0.0.8-alpha
+dotnet add package Groq.Sdk.Extensions.DependencyInjection --version 2.0.0.8-alpha
 ```
 
 > **💡 Package Selection Guide:**
@@ -414,7 +414,8 @@ Console.WriteLine(message);
 using Groq.Core.Builders;
 using Groq.Core.Models;
 
-var request = ChatCompletionRequestBuilder.Create()
+var request = ChatCompletionRequestBuilder
+    .Builder()
     .WithModel(ChatModels.LLAMA_3_3_70B_VERSATILE.Id)
     .WithUserPrompt("Explain quantum computing in simple terms.")
     .WithSystemPrompt("You are a helpful assistant.")
@@ -435,14 +436,6 @@ Console.WriteLine(message);
 -   ✅ Automatic validation of required parameters
 -   ✅ Fluent, readable API
 -   ✅ Support for all 34+ Groq API parameters
-
-**New in v2.0.0.5:** Separate convenience methods for better clarity:
-
--   `WithUserPrompt(string)` - Set the user's message (required)
--   `WithSystemPrompt(string)` - Set system context/instructions (optional)
--   `WithAssistantPrompt(string)` - Add assistant context (optional)
--   `WithImageUrl(string)` - Add image for vision models (optional)
--   `WithMessages(JsonArray)` - Full control over message structure (advanced)
 
 **⚠️ Important:** If you use `WithMessages()` directly, the convenience methods (`WithUserPrompt`, `WithSystemPrompt`, etc.) will have no effect.
 
@@ -854,6 +847,9 @@ var options = new GroqOptions
     // Optional - Timeout Configuration
     Timeout = TimeSpan.FromSeconds(100), // Default: 100 seconds
 
+    // Optional - Attempt Timeout
+    AttemptTimeout = TimeSpan.FromSeconds(10), // Default: 10 seconds per attempt
+
     // Optional - Retry Configuration
     MaxRetries = 3, // Default: 3 attempts
     Delay = TimeSpan.FromSeconds(2), // Default: 2 seconds initial delay
@@ -873,6 +869,7 @@ builder.AddGroqApiServices(options =>
     options.ApiKey = builder.Configuration["Groq:ApiKey"]!;
     options.Model = "llama-3.3-70b-versatile";
     options.Timeout = TimeSpan.FromSeconds(120);
+    options.AttemptTimeout = TimeSpan.FromSeconds(15);
     options.MaxRetries = 5;
     options.Delay = TimeSpan.FromSeconds(1);
     options.MaxDelay = TimeSpan.FromSeconds(30);
@@ -886,10 +883,11 @@ builder.AddGroqApiServices(options =>
     "Groq": {
         "ApiKey": "your-api-key-here",
         "Model": "llama-3.3-70b-versatile",
-        "Timeout": "00:01:40",
+        "Timeout": "100",
+        "AttemptTimeout": "10",
         "MaxRetries": 3,
-        "Delay": "00:00:02",
-        "MaxDelay": "00:00:20"
+        "Delay": "2",
+        "MaxDelay": "20"
     }
 }
 ```


### PR DESCRIPTION
### Summary

- Renamed `Create` to `Builder` in `ChatCompletionRequestBuilder`.
- Updated all corresponding usages across the codebase to align with the new name.
- Updated related documentation to reflect changes.
- Revised `LICENSE` as part of standard updates.
- Bumped version to `2.0.0.8`. 

### Checklist

- [x] Code changes have been reviewed and approved.
- [x] Documentation has been updated as needed.
- [x] Unit tests or other testing have been conducted to ensure functionality.  